### PR TITLE
Change the duration to 0 to fix Live videos

### DIFF
--- a/src/mobile/Controls.tsx
+++ b/src/mobile/Controls.tsx
@@ -19,10 +19,12 @@ type Props = {
   fullScreen: Boolean;
   duration: number;
   currentTime: number;
+  isLive:Boolean;
   playVideo: () => void;
   pauseVideo: () => void;
   seekTo: (t: number) => void;
   toggleFS: () => void;
+  
   topBar?: ({
     play,
     fullScreen
@@ -43,6 +45,7 @@ export default ({
   seekTo,
   toggleFS,
   fullScreen,
+  isLive,
   showFullScreenButton
 }: Props) => {
   const [visible, setVisible] = useState(true);
@@ -66,7 +69,7 @@ export default ({
     };
   }, [play, ready]);
   const progress =
-    currentTime !== 0 && duration !== 0 ? currentTime / duration : 0;
+    isLive?currentTime = duration = 0: currentTime !== 0 && duration !== 0 ? currentTime / duration : 0;
 
   return (
     <View

--- a/src/mobile/Controls.tsx
+++ b/src/mobile/Controls.tsx
@@ -70,7 +70,6 @@ export default ({
   }, [play, ready]);
   const progress =
     isLive?currentTime = duration = 0: currentTime !== 0 && duration !== 0 ? currentTime / duration : 0;
-
   return (
     <View
       style={[styles.container, { paddingHorizontal: fullScreen ? 40 : 0 }]}
@@ -102,7 +101,7 @@ export default ({
             <View style={[styles.footer, { bottom: fullScreen ? 30 : 10 }]}>
               <Text style={styles.text}> {sec2time(currentTime)} </Text>
               <View style={styles.footerRight}>
-                <Text style={styles.text}> {sec2time(duration)} </Text>
+                <Text style={styles.text}> {sec2time(!isLive?duration:0)} </Text>
                 {showFullScreenButton && (
                   <React.Fragment>
                     {fullScreen ? (
@@ -119,7 +118,7 @@ export default ({
       )}
       <ProgressBar
         value={progress}
-        {...{ fullScreen, visible, seekTo, duration, pauseVideo, playVideo }}
+        {...{ fullScreen, visible, seekTo, duration, pauseVideo, playVideo, isLive }}
       />
     </View>
   );

--- a/src/mobile/Player.tsx
+++ b/src/mobile/Player.tsx
@@ -56,14 +56,8 @@ export default class Player extends PureComponent<PlayerProps, PlayerState> {
 
   // listeners
   onDurationReady = (duration: number) => {
-    if(!this.props.isLive){
-      this.setState({ duration });
-      this.props.onDurationReady(duration);
-    }else{
-      this.setState({ duration:0 });
-      this.props.onDurationReady(0);
-    }
-    
+    this.setState({ duration });
+    this.props.onDurationReady(duration);
     this.props.onStart();
   };
 

--- a/src/mobile/Player.tsx
+++ b/src/mobile/Player.tsx
@@ -56,8 +56,14 @@ export default class Player extends PureComponent<PlayerProps, PlayerState> {
 
   // listeners
   onDurationReady = (duration: number) => {
-    this.setState({ duration });
-    this.props.onDurationReady(duration);
+    if(!this.props.isLive){
+      this.setState({ duration });
+      this.props.onDurationReady(duration);
+    }else{
+      this.setState({ duration:0 });
+      this.props.onDurationReady(0);
+    }
+    
     this.props.onStart();
   };
 

--- a/src/mobile/Player.tsx
+++ b/src/mobile/Player.tsx
@@ -199,7 +199,7 @@ export default class Player extends PureComponent<PlayerProps, PlayerState> {
     const AbsoluteStyle = IsAndroid ? { ...this.state.layout } : {};
 
     const { playVideo, pauseVideo, seekTo, toggleFS } = this;
-    const { videoId, autoPlay, topBar, showFullScreenButton } = this.props;
+    const { videoId, autoPlay, topBar, showFullScreenButton, isLive } = this.props;
     const style: any = {
       ...VideoStyle,
       ...AbsoluteStyle,
@@ -237,6 +237,7 @@ export default class Player extends PureComponent<PlayerProps, PlayerState> {
                   toggleFS,
                   topBar,
                   showFullScreenButton,
+                  isLive
                   ...this.state
                 }}
               />
@@ -266,6 +267,7 @@ export default class Player extends PureComponent<PlayerProps, PlayerState> {
                 toggleFS,
                 topBar,
                 showFullScreenButton,
+                isLive,
                 ...this.state
               }}
             />

--- a/src/mobile/Player.tsx
+++ b/src/mobile/Player.tsx
@@ -237,7 +237,7 @@ export default class Player extends PureComponent<PlayerProps, PlayerState> {
                   toggleFS,
                   topBar,
                   showFullScreenButton,
-                  isLive
+                  isLive,
                   ...this.state
                 }}
               />

--- a/src/mobile/ProgressBar.tsx
+++ b/src/mobile/ProgressBar.tsx
@@ -11,6 +11,7 @@ type Props = {
   playVideo: () => void;
   pauseVideo: () => void;
   seekTo: (t: number) => void;
+  isLive:Boolean;
 };
 
 export default ({
@@ -30,7 +31,7 @@ export default ({
         minimumValue={0}
         onSlidingStart={pauseVideo}
         onSlidingComplete={p => {
-          seekTo(p * duration);
+          !isLive?seekTo(p * duration):seekTo(p * 0);
           playVideo();
         }}
         maximumValue={1}

--- a/src/mobile/ProgressBar.tsx
+++ b/src/mobile/ProgressBar.tsx
@@ -21,7 +21,8 @@ export default ({
   duration,
   pauseVideo,
   playVideo,
-  fullScreen
+  fullScreen,
+  isLive
 }: Props) => (
   <View style={[styles.container, { bottom: fullScreen ? 20 : 0 }]}>
     <Progress progress={value} />

--- a/src/mobile/types.tsx
+++ b/src/mobile/types.tsx
@@ -63,6 +63,7 @@ export interface PlayerProps extends YTWebViewProps {
   showFullScreenButton?: Boolean;
   onFullScreen?: (fullscreen: Boolean) => void;
   onStart?: () => void;
+  isLive?: Boolean;
 }
 
 export const PlayerDefaultProps = {


### PR DESCRIPTION
Hi,
I created a property on player called 'isLive' to watch live videos with your player.
Live videos return infinite values to duration crashing the player, what i did was changing the duration to 0 when the property 'isLive' is found.
Thank you